### PR TITLE
Fixed how spec s handles precision

### DIFF
--- a/_putchar.c
+++ b/_putchar.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <unistd.h>
 /**
  * _putchar - writes the character c to stdout

--- a/conversion_cs.c
+++ b/conversion_cs.c
@@ -25,18 +25,15 @@ int printString(va_list input, mods *m, char **index)
 	int count = 0, total = 0;
 	char *str;
 
-	if (m->precision == -1)
-		m->precision = 1024;
-
 	str = va_arg(input, char *);
 	if (str == NULL)
 		str = "(null)";
-	while (str[count] && count < m->precision)
+	while (str[count] && (count < m->precision || m->precision == -1))
 	{
 		total += _putchar(str[count], index);
 		count++;
 	}
-	m->precision = -1;
+
 	return (total);
 }
 


### PR DESCRIPTION
no more are the days of the arbitrary 1024 cap of precision (which was causing the maximum num of characters to never be higher than 1024). Now if precision is -1, it is ignored and the whole string prints. Sweet!