### PR TITLE
removed unneeded 8 digit force

### DIFF
--- a/conversion_p.c
+++ b/conversion_p.c
@@ -10,7 +10,7 @@
 int printAddress(va_list input, mods *m, char **index)
 {
 	int total = 0;
-	unsigned long int addr = va_arg(input, unsigned long int), temp = addr;
+	unsigned long int addr = va_arg(input, unsigned long int);
 
 	(void)m;
 
@@ -25,12 +25,6 @@ int printAddress(va_list input, mods *m, char **index)
 
 	total += _putchar('0', index);
 	total += _putchar('x', index);
-
-	while (temp < 10000000)
-	{
-		total += _putchar('0', index);
-		temp *= 10;
-	}
 
 	return (total + address_recursion(addr, index));
 }


### PR DESCRIPTION
the other commit appears to have fixed everything.
now prints (nil) when pointer is NULL
now has its own recursion function to handle long ints since the original hex_recursion is forced to handle only ints