### PR TITLE
to shorten _printf, the buffer_init function was created

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -9,7 +9,7 @@
  */
 int _printf(const char *format, ...)
 {
-	int i = 0, k = 0, c = 0, total = 0, *j = &i;
+	int i = 0, c = 0, total = 0, *j = &i;
 	int (*f)(va_list, mods *, char **);
 	va_list input;
 	char buffer[1024], *p = buffer, **index = &p;
@@ -17,14 +17,13 @@ int _printf(const char *format, ...)
 
 	if (m == NULL || format == NULL)
 		return (-1);
-	for (k = 0; k < 1023; k++)
-		buffer[k] = '!';
-	buffer[1023] = '\0';
+	buffer_init(index);
 	va_start(input, format);
 	while (format[i])
 	{
-		if (format[i++] == '%')
+		if (format[i] == '%')
 		{
+			i++;
 			get_mods(format, m, j);
 			if (m->key != '\0')
 			{
@@ -38,8 +37,8 @@ int _printf(const char *format, ...)
 				free(m);
 				return (-1);
 			}
+			total += _putchar('%', index);
 		}
-		i--;
 		total += _putchar(format[i++], index);
 	}
 	va_end(input);
@@ -49,4 +48,17 @@ int _printf(const char *format, ...)
 		c++;
 	write(1, &buffer, c);
 	return (total + c);
+}
+
+/**
+* buffer_init - initializes the buffer to non NULL memory
+* @buffer: buffer to initialize
+*/
+void buffer_init(char **buffer)
+{
+	int i = 0;
+
+	for (i = 0; i < 1023; i++)
+		(*buffer)[i] = '!';
+	(*buffer)[1023] = '\0';
 }

--- a/holberton.h
+++ b/holberton.h
@@ -47,6 +47,7 @@ int _printf(const char *str, ...);
 int h_m(int (*f)(va_list, mods *, char **), mods *m, va_list inp, char **ind);
 void get_mods(const char *format, mods *out, int *i);
 void mods_init(mods *out);
+void buffer_init(char **buffer);
 int get_int(const char *format, int *i);
 int _atoi(char *buffer);
 int handle_flags(const char *format, mods *out, int k);


### PR DESCRIPTION
1 line too long and I couldn't shorten it any other way.